### PR TITLE
Better expression ergonomics

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,11 +16,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
-          toolchain: stable
-          override: true
+        toolchain: stable
+        components: clippy
+    - name: Install cargo expand
+      run: cargo install cargo-expand
+    - name: Build
+      run: cargo build --verbose --all-features
+    - name: Run clippy
+      run: cargo clippy -- --D warnings
+    - name: Run tests
+      run: cargo test --verbose --all-features
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly
+        components: rustfmt
+    - name: Run fmt check
+      run: cargo +nightly fmt --check

--- a/impl/src/code_gen/gen_read.rs
+++ b/impl/src/code_gen/gen_read.rs
@@ -118,8 +118,8 @@ fn wrap_in_optional(when_expr: &syn::Expr, inner: TokenStream) -> TokenStream {
 /// 5. If an 'assertion' attribute is present, then generate code to assert on the read value using
 ///    the given assertion function or closure.
 /// 6. After the code to perform the read has been generated, we check if the field is an option
-///    type.  If so, a 'when' attribute is required.  This is an expression that determines when
-///    the read should actually be done.
+///    type.  If so, a 'when' attribute is required.  This is an expression that determines when the
+///    read should actually be done.
 /// 7. Finally, if an 'alignment' attribute is present, code is added to detect and consume any
 ///    padding after the read.
 fn generate_field_read(field_data: &ParselyReadFieldData) -> TokenStream {
@@ -146,9 +146,9 @@ fn generate_field_read(field_data: &ParselyReadFieldData) -> TokenStream {
         } else {
             panic!("Collection field '{field_name}' must have either 'count' or 'while' attribute");
         };
-        output.extend(generate_collection_read(limit, read_type, context_values));
+        output.extend(generate_collection_read(limit, read_type, &context_values));
     } else {
-        output.extend(generate_plain_read(read_type, context_values));
+        output.extend(generate_plain_read(read_type, &context_values));
     }
 
     // println!("tokenstream: {}", output);

--- a/impl/src/code_gen/gen_write.rs
+++ b/impl/src/code_gen/gen_write.rs
@@ -56,7 +56,7 @@ fn generate_parsely_write_impl_struct(
             // TODO: these write calls should be qualified.  Something like <#write_type as
             // ParselyWrite>::write
             if let Some(ref map_expr) = f.common.map {
-                map_expr.to_write_map_tokens(field_name, &mut field_write_output); 
+                map_expr.to_write_map_tokens(field_name, &mut field_write_output);
             } else if f.ty.is_option() {
                 field_write_output.extend(quote! {
                     if let Some(ref v) = self.#field_name {

--- a/impl/src/code_gen/gen_write.rs
+++ b/impl/src/code_gen/gen_write.rs
@@ -30,6 +30,7 @@ fn generate_parsely_write_impl_struct(
     struct_alignment: Option<usize>,
     sync_args: Option<TypedFnArgList>,
 ) -> TokenStream {
+    // TODO: call sync on all fields
     let crate_name = get_crate_name();
     let (context_assignments, context_types) = if let Some(ref required_context) = required_context
     {
@@ -159,7 +160,8 @@ fn generate_parsely_write_impl_struct(
             }
         }
 
-        impl StateSync<(#(#sync_args_types,)*)> for #struct_name {
+        impl StateSync for #struct_name {
+            type SyncCtx = (#(#sync_args_types,)*);
             fn sync(&mut self, (#(#sync_args_variables,)*): (#(#sync_args_types,)*)) -> ParselyResult<()> {
                 #(#sync_field_calls)*
 

--- a/impl/src/code_gen/gen_write.rs
+++ b/impl/src/code_gen/gen_write.rs
@@ -58,18 +58,21 @@ fn generate_parsely_write_impl_struct(
             } else if f.ty.is_option() {
                 field_write_output.extend(quote! {
                     if let Some(ref v) = self.#field_name {
-                        #write_type::write::<T>(v, buf, (#(#context_values,)*)).with_context(|| format!("Writing field '{}'", #field_name_string))?;
+                        ::#crate_name::WriteAdaptor::new(v).write::<T>(buf, (#(#context_values,)*)).with_context(|| format!("Writing field '{}'", #field_name_string))?;
+                        // #write_type::write::<T>(v, buf, (#(#context_values,)*)).with_context(|| format!("Writing field '{}'", #field_name_string))?;
                     }
                 });
             } else if f.ty.is_collection() {
                 field_write_output.extend(quote! {
                     self.#field_name.iter().enumerate().map(|(idx, v)| {
-                        #write_type::write::<T>(v, buf, (#(#context_values,)*)).with_context(|| format!("Index {idx}"))
+                        ::#crate_name::WriteAdaptor::new(v).write::<T>(buf, (#(#context_values,)*)).with_context(|| format!("Index {idx}"))
+                        // #write_type::write::<T>(v, buf, (#(#context_values,)*)).with_context(|| format!("Index {idx}"))
                     }).collect::<ParselyResult<Vec<_>>>().with_context(|| format!("Writing field '{}'", #field_name_string))?;
                 });
             } else {
                 field_write_output.extend(quote! {
-                    #write_type::write::<T>(&self.#field_name, buf, (#(#context_values,)*)).with_context(|| format!("Writing field '{}'", #field_name_string))?;
+                    ::#crate_name::WriteAdaptor::new(&self.value.#field_name).write::<T>(buf, (#(#context_values,)*)).with_context(|| format!("Writing field '{}'", #field_name_string))?;
+                    // #write_type::write::<T>(&self.#field_name, buf, (#(#context_values,)*)).with_context(|| format!("Writing field '{}'", #field_name_string))?;
                 });
             }
 
@@ -140,8 +143,11 @@ fn generate_parsely_write_impl_struct(
     };
 
     quote! {
-        impl<B: BitBufMut> ::#crate_name::ParselyWrite<B, (#(#context_types,)*)> for #struct_name {
-            fn write<T: ::#crate_name::ByteOrder>(&self, buf: &mut B, ctx: (#(#context_types,)*)) -> ::#crate_name::ParselyResult<()> {
+        impl<'a, B: BitBufMut> ::#crate_name::ParselyWrite for ::#crate_name::WriteAdaptor<'a, #struct_name, B> {
+            type Buf = B;
+            type Ctx = (#(#context_types,)*);
+
+            fn write<T: ByteOrder>(&self, buf: &mut Self::Buf, _: Self::Ctx) -> ParselyResult<()> {
                 #(#context_assignments)*
 
                 #body

--- a/impl/src/code_gen/gen_write.rs
+++ b/impl/src/code_gen/gen_write.rs
@@ -120,7 +120,7 @@ fn generate_parsely_write_impl_struct(
                 // provided.
                 quote! {}
             } else {
-                let sync_with = f.sync_with.expressions();
+                let sync_with = f.sync_with_expressions();
                 quote! {
                     self.#field_name.sync((#(#sync_with,)*)).with_context(|| format!("Syncing field '{}'", #field_name_string))?;
                 }

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -1,14 +1,16 @@
-use crate::parsely_write::{ParselyWrite, ParselyWrite2};
+use crate::parsely_write::ParselyWrite;
 
 pub type ParselyResult<T> = anyhow::Result<T>;
 
-pub trait IntoParselyResult<T> {
+/// Helper trait to coerce values of both `T: ParselyWrite` and `Result<T, E>: E:
+/// Into<anyhow::Error>` into `ParselyResult<T>`.  We need a trait specifically for writing because
+/// if we don't bound the impl for `T` in some way there's ambiguity: the compiler doesn't know if
+/// we want `ParselyResult<T>` or `ParselyResult<Result<T, E>>`.
+pub trait IntoWritableParselyResult<T> {
     fn into_parsely_result(self) -> ParselyResult<T>;
 }
 
-// TODO: change this to be bound by T: ParselyWrite once ParselyWrite is changed to use associated
-// types
-impl<T> IntoParselyResult<T> for T
+impl<T> IntoWritableParselyResult<T> for T
 where
     T: ParselyWrite,
 {
@@ -17,7 +19,7 @@ where
     }
 }
 
-impl<T, E> IntoParselyResult<T> for Result<T, E>
+impl<T, E> IntoWritableParselyResult<T> for Result<T, E>
 where
     E: Into<anyhow::Error>,
 {
@@ -26,6 +28,26 @@ where
     }
 }
 
-pub fn wrap_in_parsely_result<T>(value: impl IntoParselyResult<T>) -> ParselyResult<T> {
-    value.into_parsely_result()
+/// When we need to convert an expression that may or may not be wrapped in a Result on the _read_
+/// path, we can rely on the fact that we'll eventually be assigning the value to a field with a
+/// concrete type and we can rely on type inference in order to figure out what that should be.
+/// Because of that we don't want/need the `ParselyWrite` trait bounds on the impl like we have
+/// above for the writable side, so we need a different trait here.
+pub trait IntoParselyResult<T> {
+    fn into_parsely_result_read(self) -> ParselyResult<T>;
+}
+
+impl<T> IntoParselyResult<T> for T {
+    fn into_parsely_result_read(self) -> ParselyResult<T> {
+        Ok(self)
+    }
+}
+
+impl<T, E> IntoParselyResult<T> for Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn into_parsely_result_read(self) -> ParselyResult<T> {
+        self.map_err(Into::into)
+    }
 }

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -1,1 +1,24 @@
 pub type ParselyResult<T> = anyhow::Result<T>;
+
+pub trait IntoParselyResult<T> {
+    fn into_parsely_result(self) -> ParselyResult<T>;
+}
+
+impl<T> IntoParselyResult<T> for T {
+    fn into_parsely_result(self) -> ParselyResult<T> {
+        Ok(self)
+    }
+}
+
+impl<T, E> IntoParselyResult<T> for Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn into_parsely_result(self) -> ParselyResult<T> {
+        self.map_err(Into::into)
+    }
+}
+
+pub fn wrap_in_parsely_result<T>(value: impl IntoParselyResult<T>) -> ParselyResult<T> {
+    value.into_parsely_result()
+}

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -4,6 +4,8 @@ pub trait IntoParselyResult<T> {
     fn into_parsely_result(self) -> ParselyResult<T>;
 }
 
+// TODO: change this to be bound by T: ParselyWrite once ParselyWrite is changed to use associated
+// types
 impl<T> IntoParselyResult<T> for T {
     fn into_parsely_result(self) -> ParselyResult<T> {
         Ok(self)

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -1,3 +1,5 @@
+use crate::parsely_write::{ParselyWrite, ParselyWrite2};
+
 pub type ParselyResult<T> = anyhow::Result<T>;
 
 pub trait IntoParselyResult<T> {
@@ -6,7 +8,10 @@ pub trait IntoParselyResult<T> {
 
 // TODO: change this to be bound by T: ParselyWrite once ParselyWrite is changed to use associated
 // types
-impl<T> IntoParselyResult<T> for T {
+impl<T> IntoParselyResult<T> for T
+where
+    T: ParselyWrite,
+{
     fn into_parsely_result(self) -> ParselyResult<T> {
         Ok(self)
     }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -109,11 +109,16 @@ impl ParselyReadFieldData {
     }
 
     /// Get the context values that need to be passed to the read or write call for this field
-    pub(crate) fn context_values(&self) -> &[syn::Expr] {
+    pub(crate) fn context_values(&self) -> Vec<syn::Expr> {
+        let field_name = self
+            .ident
+            .as_ref()
+            .expect("Field must have a name")
+            .to_string();
         if let Some(ref field_context) = self.common.context {
-            field_context.expressions()
+            field_context.expressions(&format!("Read context for field '{field_name}'"))
         } else {
-            &[]
+            vec![]
         }
     }
 }
@@ -154,12 +159,28 @@ impl ParselyWriteFieldData {
     }
 
     /// Get the context values that need to be passed to the read or write call for this field
-    pub(crate) fn context_values(&self) -> &[syn::Expr] {
+    pub(crate) fn context_values(&self) -> Vec<syn::Expr> {
+        let field_name = self
+            .ident
+            .as_ref()
+            .expect("Field must have a name")
+            .to_string();
         if let Some(ref field_context) = self.common.context {
-            field_context.expressions()
+            field_context.expressions(&format!("Write context for field '{field_name}'"))
         } else {
-            &[]
+            vec![]
         }
+    }
+
+    /// Get the context values that need to be passed to the read or write call for this field
+    pub(crate) fn sync_with_expressions(&self) -> Vec<syn::Expr> {
+        let field_name = self
+            .ident
+            .as_ref()
+            .expect("Field must have a name")
+            .to_string();
+        self.sync_with
+            .expressions(&format!("Sync context for field '{field_name}'"))
     }
 }
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -26,7 +26,7 @@ pub mod anyhow {
 
 use code_gen::{gen_read::generate_parsely_read_impl, gen_write::generate_parsely_write_impl};
 use darling::{ast, FromDeriveInput, FromField, FromMeta};
-use model_types::{Assertion, Context, ExprOrFunc, FuncOrClosure, TypedFnArgList};
+use model_types::{Assertion, Context, ExprOrFunc, MapExpr, TypedFnArgList};
 use proc_macro2::TokenStream;
 use syn::DeriveInput;
 use syn_helpers::TypeExts;
@@ -63,7 +63,7 @@ pub struct ParselyCommonFieldData {
     context: Option<Context>,
 
     /// An optional mapping that will be applied to the read value
-    map: Option<FuncOrClosure>,
+    map: Option<MapExpr>,
 
     /// An optional indicator that this field is or needs to be aligned to the given byte alignment
     /// via padding.

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -26,7 +26,7 @@ pub mod anyhow {
 
 use code_gen::{gen_read::generate_parsely_read_impl, gen_write::generate_parsely_write_impl};
 use darling::{ast, FromDeriveInput, FromField, FromMeta};
-use model_types::{Context, ExprOrFunc, FuncOrClosure, TypedFnArgList};
+use model_types::{Assertion, Context, ExprOrFunc, FuncOrClosure, TypedFnArgList};
 use proc_macro2::TokenStream;
 use syn::DeriveInput;
 use syn_helpers::TypeExts;
@@ -57,7 +57,7 @@ pub struct ParselyCommonFieldData {
     // See https://github.com/TedDriggs/darling/issues/330
 
     // generics: Option<syn::Ident>,
-    assertion: Option<FuncOrClosure>,
+    assertion: Option<Assertion>,
 
     /// Values that need to be passed as context to this fields read or write method
     context: Option<Context>,

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -133,9 +133,9 @@ pub struct ParselyWriteFieldData {
     #[darling(flatten)]
     common: ParselyCommonFieldData,
 
-    /// An optional function or closure that will be called to synchronize this field based on some
-    /// external data
-    sync_func: Option<ExprOrFunc>,
+    /// An expression or function call that will be used to update this field in the generated
+    /// `StateSync` implementation for its parent type.
+    sync_expr: Option<ExprOrFunc>,
 
     /// An list of expressions that should be passed as context to this field's sync method.  The
     /// sync method provides an opportunity to synchronize "linked" fields, where one field's value

--- a/impl/src/model_types.rs
+++ b/impl/src/model_types.rs
@@ -263,7 +263,7 @@ impl MapExpr {
             {
                 let original_value = ::#crate_name::ParselyRead::read::<T>(buf, ())
                     .with_context(|| format!("Reading raw value for field '{}'", #field_name_string))?;
-                (#map_expr)(original_value).into_parsely_result()
+                (#map_expr)(original_value).into_parsely_result_read()
                     .with_context(|| format!("Mapping raw value for field '{}'", #field_name_string))
             }
         })
@@ -277,7 +277,7 @@ impl MapExpr {
             {
                 let mapped_value = (#map_expr)(&self.#field_name).into_parsely_result()
                     .with_context(|| format!("Mapping raw value for field '{}'", #field_name_string))?;
-                ::#crate_name::ParselyWrite::write::<T>(&mapped_value, buf, ())
+                ::#crate_name::ParselyWrite::write::<B, _, T>(&mapped_value, buf, ())
                     .with_context(|| format!("Writing mapped value for field '{}'", #field_name_string))?;
             }
         })

--- a/impl/src/model_types.rs
+++ b/impl/src/model_types.rs
@@ -75,7 +75,7 @@ impl Context {
         // We support Context expressions that return a ParselyResult or a raw value.  So now wrap
         // all the expressions with code that will normalize all of the results into
         // ParselyResults.
-       self.0 
+        self.0
             .iter()
             .cloned()
             .enumerate()
@@ -283,8 +283,6 @@ impl MapExpr {
         })
     }
 }
-
-
 
 /// An assertion that can be used after reading a value or before writing one
 #[derive(Debug)]

--- a/impl/src/parsely_write.rs
+++ b/impl/src/parsely_write.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use bits_io::prelude::*;
 
 use crate::error::ParselyResult;
@@ -22,16 +24,84 @@ macro_rules! impl_stateless_sync {
     };
 }
 
-pub trait ParselyWrite<B, Ctx>: StateSync + Sized {
+pub trait ParselyWrite2<B, Ctx>: StateSync + Sized {
     fn write<T: ByteOrder>(&self, buf: &mut B, ctx: Ctx) -> ParselyResult<()>;
+}
+
+pub trait ParselyWrite: StateSync + Sized {
+    type Buf: BitBufMut;
+    type Ctx;
+    fn write<T: ByteOrder>(&self, buf: &mut Self::Buf, ctx: Self::Ctx) -> ParselyResult<()>;
+}
+
+pub struct WriteAdaptor<'a, T, B> {
+    pub value: &'a T,
+    _buf: PhantomData<B>,
+}
+
+impl<'a, T, B> WriteAdaptor<'a, T, B> {
+    pub fn new(value: &'a T) -> Self {
+        Self {
+            value,
+            _buf: PhantomData,
+        }
+    }
+}
+
+// The `WriteAdaptor` type enables two things:
+// 1. We can now use `ParselyWrite` as a trait bounds, which is useful to allow type inference for
+//    scenarios like the `map` functionality on the write path, where we don't have a concrete type
+//    to infer the result of the map function to, other than something that can be written.
+// 2. Allows us to avoid having to define a concrete associated type in the impls of ParselyWrite:
+//    since we can use the generics on WriteAdaptor to set as the associated typed in the
+//    ParselyWrite impl.
+//
+// One downside of it, though, is that now a `WriteAdaptor` instance needs to be created to do
+// writes.  This isn't a performance concern, but is a bit awkward from an API perspective
+
+pub trait ParselyWritableExt {
+    fn write_with<'a, B, BO>(
+        &'a self,
+        buf: &mut B,
+        ctx: <WriteAdaptor<'a, Self, B> as ParselyWrite>::Ctx,
+    ) -> ParselyResult<()>
+    where
+        Self: Sized,
+        B: BitBufMut,
+        BO: ByteOrder,
+        WriteAdaptor<'a, Self, B>: ParselyWrite<Buf = B>;
+}
+
+impl<T> ParselyWritableExt for T {
+    fn write_with<'a, B, BO>(
+        &'a self,
+        buf: &mut B,
+        ctx: <WriteAdaptor<'a, Self, B> as ParselyWrite>::Ctx,
+    ) -> ParselyResult<()>
+    where
+        B: BitBufMut,
+        BO: ByteOrder,
+        WriteAdaptor<'a, Self, B>: ParselyWrite<Buf = B>,
+    {
+        WriteAdaptor::<_, B>::new(self).write::<BO>(buf, ctx)
+    }
 }
 
 macro_rules! impl_parsely_write_builtin {
     ($type:ty) => {
-        impl<B: BitBufMut> ParselyWrite<B, ()> for $type {
+        impl<B: BitBufMut> ParselyWrite2<B, ()> for $type {
             fn write<T: ByteOrder>(&self, buf: &mut B, _: ()) -> ParselyResult<()> {
                 ::paste::paste! {
                     Ok(buf.[<put_ $type>](*self)?)
+                }
+            }
+        }
+        impl<'a, B: BitBufMut> ParselyWrite for WriteAdaptor<'a, $type, B> {
+            type Buf = B;
+            type Ctx = ();
+            fn write<T: ByteOrder>(&self, buf: &mut Self::Buf, _: Self::Ctx) -> ParselyResult<()> {
+                ::paste::paste! {
+                    Ok(buf.[<put_ $type>](*self.value)?)
                 }
             }
         }
@@ -40,10 +110,19 @@ macro_rules! impl_parsely_write_builtin {
 
 macro_rules! impl_parsely_write_builtin_bo {
     ($type:ty) => {
-        impl<B: BitBufMut> ParselyWrite<B, ()> for $type {
+        impl<B: BitBufMut> ParselyWrite2<B, ()> for $type {
             fn write<T: ByteOrder>(&self, buf: &mut B, _: ()) -> ParselyResult<()> {
                 ::paste::paste! {
                     Ok(buf.[<put_ $type>]::<T>(*self)?)
+                }
+            }
+        }
+        impl<'a, B: BitBufMut> ParselyWrite for WriteAdaptor<'a, $type, B> {
+            type Buf = B;
+            type Ctx = ();
+            fn write<T: ByteOrder>(&self, buf: &mut Self::Buf, _: Self::Ctx) -> ParselyResult<()> {
+                ::paste::paste! {
+                    Ok(buf.[<put_ $type>]::<T>(*self.value)?)
                 }
             }
         }
@@ -66,6 +145,12 @@ macro_rules! for_all {
 macro_rules! impl_state_sync_builtin {
     ($type:ty) => {
         impl StateSync for $type {
+            type SyncCtx = ();
+            fn sync(&mut self, _sync_ctx: ()) -> ParselyResult<()> {
+                Ok(())
+            }
+        }
+        impl<'a, B: BitBufMut> StateSync for WriteAdaptor<'a, $type, B> {
             type SyncCtx = ();
             fn sync(&mut self, _sync_ctx: ()) -> ParselyResult<()> {
                 Ok(())

--- a/impl/src/parsely_write.rs
+++ b/impl/src/parsely_write.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use bits_io::prelude::*;
 
 use crate::error::ParselyResult;
@@ -24,84 +22,20 @@ macro_rules! impl_stateless_sync {
     };
 }
 
-pub trait ParselyWrite2<B, Ctx>: StateSync + Sized {
-    fn write<T: ByteOrder>(&self, buf: &mut B, ctx: Ctx) -> ParselyResult<()>;
-}
-
 pub trait ParselyWrite: StateSync + Sized {
-    type Buf: BitBufMut;
-    type Ctx;
-    fn write<T: ByteOrder>(&self, buf: &mut Self::Buf, ctx: Self::Ctx) -> ParselyResult<()>;
-}
-
-pub struct WriteAdaptor<'a, T, B> {
-    pub value: &'a T,
-    _buf: PhantomData<B>,
-}
-
-impl<'a, T, B> WriteAdaptor<'a, T, B> {
-    pub fn new(value: &'a T) -> Self {
-        Self {
-            value,
-            _buf: PhantomData,
-        }
-    }
-}
-
-// The `WriteAdaptor` type enables two things:
-// 1. We can now use `ParselyWrite` as a trait bounds, which is useful to allow type inference for
-//    scenarios like the `map` functionality on the write path, where we don't have a concrete type
-//    to infer the result of the map function to, other than something that can be written.
-// 2. Allows us to avoid having to define a concrete associated type in the impls of ParselyWrite:
-//    since we can use the generics on WriteAdaptor to set as the associated typed in the
-//    ParselyWrite impl.
-//
-// One downside of it, though, is that now a `WriteAdaptor` instance needs to be created to do
-// writes.  This isn't a performance concern, but is a bit awkward from an API perspective
-
-pub trait ParselyWritableExt {
-    fn write_with<'a, B, BO>(
-        &'a self,
-        buf: &mut B,
-        ctx: <WriteAdaptor<'a, Self, B> as ParselyWrite>::Ctx,
-    ) -> ParselyResult<()>
-    where
-        Self: Sized,
-        B: BitBufMut,
-        BO: ByteOrder,
-        WriteAdaptor<'a, Self, B>: ParselyWrite<Buf = B>;
-}
-
-impl<T> ParselyWritableExt for T {
-    fn write_with<'a, B, BO>(
-        &'a self,
-        buf: &mut B,
-        ctx: <WriteAdaptor<'a, Self, B> as ParselyWrite>::Ctx,
-    ) -> ParselyResult<()>
-    where
-        B: BitBufMut,
-        BO: ByteOrder,
-        WriteAdaptor<'a, Self, B>: ParselyWrite<Buf = B>,
-    {
-        WriteAdaptor::<_, B>::new(self).write::<BO>(buf, ctx)
-    }
+    fn write<B: BitBufMut, Ctx, T: ByteOrder>(&self, buf: &mut B, ctx: Ctx) -> ParselyResult<()>;
 }
 
 macro_rules! impl_parsely_write_builtin {
     ($type:ty) => {
-        impl<B: BitBufMut> ParselyWrite2<B, ()> for $type {
-            fn write<T: ByteOrder>(&self, buf: &mut B, _: ()) -> ParselyResult<()> {
+        impl ParselyWrite for $type {
+            fn write<B: BitBufMut, Ctx, T: ByteOrder>(
+                &self,
+                buf: &mut B,
+                _: Ctx,
+            ) -> ParselyResult<()> {
                 ::paste::paste! {
                     Ok(buf.[<put_ $type>](*self)?)
-                }
-            }
-        }
-        impl<'a, B: BitBufMut> ParselyWrite for WriteAdaptor<'a, $type, B> {
-            type Buf = B;
-            type Ctx = ();
-            fn write<T: ByteOrder>(&self, buf: &mut Self::Buf, _: Self::Ctx) -> ParselyResult<()> {
-                ::paste::paste! {
-                    Ok(buf.[<put_ $type>](*self.value)?)
                 }
             }
         }
@@ -110,19 +44,14 @@ macro_rules! impl_parsely_write_builtin {
 
 macro_rules! impl_parsely_write_builtin_bo {
     ($type:ty) => {
-        impl<B: BitBufMut> ParselyWrite2<B, ()> for $type {
-            fn write<T: ByteOrder>(&self, buf: &mut B, _: ()) -> ParselyResult<()> {
+        impl ParselyWrite for $type {
+            fn write<B: BitBufMut, Ctx, T: ByteOrder>(
+                &self,
+                buf: &mut B,
+                _: Ctx,
+            ) -> ParselyResult<()> {
                 ::paste::paste! {
                     Ok(buf.[<put_ $type>]::<T>(*self)?)
-                }
-            }
-        }
-        impl<'a, B: BitBufMut> ParselyWrite for WriteAdaptor<'a, $type, B> {
-            type Buf = B;
-            type Ctx = ();
-            fn write<T: ByteOrder>(&self, buf: &mut Self::Buf, _: Self::Ctx) -> ParselyResult<()> {
-                ::paste::paste! {
-                    Ok(buf.[<put_ $type>]::<T>(*self.value)?)
                 }
             }
         }
@@ -145,12 +74,6 @@ macro_rules! for_all {
 macro_rules! impl_state_sync_builtin {
     ($type:ty) => {
         impl StateSync for $type {
-            type SyncCtx = ();
-            fn sync(&mut self, _sync_ctx: ()) -> ParselyResult<()> {
-                Ok(())
-            }
-        }
-        impl<'a, B: BitBufMut> StateSync for WriteAdaptor<'a, $type, B> {
             type SyncCtx = ();
             fn sync(&mut self, _sync_ctx: ()) -> ParselyResult<()> {
                 Ok(())

--- a/impl/src/parsely_write.rs
+++ b/impl/src/parsely_write.rs
@@ -23,16 +23,19 @@ macro_rules! impl_stateless_sync {
 }
 
 pub trait ParselyWrite: StateSync + Sized {
-    fn write<B: BitBufMut, Ctx, T: ByteOrder>(&self, buf: &mut B, ctx: Ctx) -> ParselyResult<()>;
+    type Ctx;
+    fn write<B: BitBufMut, T: ByteOrder>(&self, buf: &mut B, ctx: Self::Ctx) -> ParselyResult<()>;
 }
 
 macro_rules! impl_parsely_write_builtin {
     ($type:ty) => {
         impl ParselyWrite for $type {
-            fn write<B: BitBufMut, Ctx, T: ByteOrder>(
+            type Ctx = ();
+
+            fn write<B: BitBufMut, T: ByteOrder>(
                 &self,
                 buf: &mut B,
-                _: Ctx,
+                _: Self::Ctx,
             ) -> ParselyResult<()> {
                 ::paste::paste! {
                     Ok(buf.[<put_ $type>](*self)?)
@@ -45,10 +48,11 @@ macro_rules! impl_parsely_write_builtin {
 macro_rules! impl_parsely_write_builtin_bo {
     ($type:ty) => {
         impl ParselyWrite for $type {
-            fn write<B: BitBufMut, Ctx, T: ByteOrder>(
+            type Ctx = ();
+            fn write<B: BitBufMut, T: ByteOrder>(
                 &self,
                 buf: &mut B,
-                _: Ctx,
+                _: Self::Ctx,
             ) -> ParselyResult<()> {
                 ::paste::paste! {
                     Ok(buf.[<put_ $type>]::<T>(*self)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,13 @@
 // TODO: these should be moved to a prelude file
 pub use parsely_impl::anyhow::{Context, anyhow, bail};
-pub use parsely_impl::error::{IntoParselyResult, ParselyResult};
+pub use parsely_impl::error::{IntoParselyResult, IntoWritableParselyResult, ParselyResult};
 pub use parsely_impl::impl_stateless_sync;
 pub use parsely_impl::nsw_types::*;
 pub use parsely_impl::{BigEndian, ByteOrder, LittleEndian, NetworkOrder};
 pub use parsely_impl::{BitBuf, BitBufExts, BitBufMut, BitBufMutExts, Bits, BitsMut};
 pub use parsely_impl::{BitCursor, BitRead, BitWrite};
 pub use parsely_impl::{
-    parsely_read::ParselyRead, parsely_write::ParselyWritableExt, parsely_write::ParselyWrite,
-    parsely_write::ParselyWrite2, parsely_write::StateSync, parsely_write::WriteAdaptor,
+    parsely_read::ParselyRead, parsely_write::ParselyWrite, parsely_write::StateSync,
 };
 pub use parsely_macro::{ParselyRead, ParselyWrite};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@ pub use parsely_impl::{BigEndian, ByteOrder, LittleEndian, NetworkOrder};
 pub use parsely_impl::{BitBuf, BitBufExts, BitBufMut, BitBufMutExts, Bits, BitsMut};
 pub use parsely_impl::{BitCursor, BitRead, BitWrite};
 pub use parsely_impl::{
-    parsely_read::ParselyRead, parsely_write::ParselyWrite, parsely_write::StateSync,
+    parsely_read::ParselyRead, parsely_write::ParselyWritableExt, parsely_write::ParselyWrite,
+    parsely_write::ParselyWrite2, parsely_write::StateSync, parsely_write::WriteAdaptor,
 };
 pub use parsely_macro::{ParselyRead, ParselyWrite};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // TODO: these should be moved to a prelude file
 pub use parsely_impl::anyhow::{Context, anyhow, bail};
-pub use parsely_impl::error::ParselyResult;
+pub use parsely_impl::error::{IntoParselyResult, ParselyResult};
 pub use parsely_impl::impl_stateless_sync;
 pub use parsely_impl::nsw_types::*;
 pub use parsely_impl::{BigEndian, ByteOrder, LittleEndian, NetworkOrder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // TODO: these should be moved to a prelude file
 pub use parsely_impl::anyhow::{Context, anyhow, bail};
 pub use parsely_impl::error::ParselyResult;
+pub use parsely_impl::impl_stateless_sync;
 pub use parsely_impl::nsw_types::*;
 pub use parsely_impl::{BigEndian, ByteOrder, LittleEndian, NetworkOrder};
 pub use parsely_impl::{BitBuf, BitBufExts, BitBufMut, BitBufMutExts, Bits, BitsMut};

--- a/tests/expand/alignment.expanded.rs
+++ b/tests/expand/alignment.expanded.rs
@@ -42,7 +42,8 @@ impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
         Ok(())
     }
 }
-impl StateSync<()> for Foo {
+impl StateSync for Foo {
+    type SyncCtx = ();
     fn sync(&mut self, (): ()) -> ParselyResult<()> {
         self.one
             .sync(())

--- a/tests/expand/alignment.expanded.rs
+++ b/tests/expand/alignment.expanded.rs
@@ -19,14 +19,15 @@ impl<B: BitBuf> ::parsely_rs::ParselyRead<B, ()> for Foo {
         Ok(Self { one })
     }
 }
-impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
-    fn write<T: ::parsely_rs::ByteOrder>(
+impl ::parsely_rs::ParselyWrite for Foo {
+    type Ctx = ();
+    fn write<B: BitBufMut, T: ByteOrder>(
         &self,
         buf: &mut B,
-        ctx: (),
-    ) -> ::parsely_rs::ParselyResult<()> {
+        ctx: Self::Ctx,
+    ) -> ParselyResult<()> {
         let __bytes_remaining_start = buf.remaining_mut_bytes();
-        u8::write::<T>(&self.one, buf, ())
+        u8::write::<_, T>(&self.one, buf, ())
             .with_context(|| ::alloc::__export::must_use({
                 let res = ::alloc::fmt::format(
                     format_args!("Writing field \'{0}\'", "one"),

--- a/tests/expand/assertion.expanded.rs
+++ b/tests/expand/assertion.expanded.rs
@@ -1,0 +1,80 @@
+use parsely_rs::*;
+struct Foo {
+    #[parsely(assertion = "|v: &u8| *v % 2 == 0")]
+    value: u8,
+}
+impl<B: BitBuf> ::parsely_rs::ParselyRead<B, ()> for Foo {
+    fn read<T: ::parsely_rs::ByteOrder>(
+        buf: &mut B,
+        _ctx: (),
+    ) -> ::parsely_rs::ParselyResult<Self> {
+        let value = u8::read::<T>(buf, ())
+            .and_then(|read_value| {
+                let assertion_func = |v: &u8| *v % 2 == 0;
+                if !assertion_func(&read_value) {
+                    return ::anyhow::__private::Err(
+                        ::anyhow::Error::msg(
+                            ::alloc::__export::must_use({
+                                let res = ::alloc::fmt::format(
+                                    format_args!(
+                                        "Assertion failed: value of field \'{0}\' (\'{1:?}\') didn\'t pass assertion: \'{2}\'",
+                                        "value", read_value, | v : & u8 | * v % 2 == 0,
+                                    ),
+                                );
+                                res
+                            }),
+                        ),
+                    );
+                }
+                Ok(read_value)
+            })
+            .with_context(|| "Reading field 'value'")?;
+        Ok(Self { value })
+    }
+}
+impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
+    fn write<T: ::parsely_rs::ByteOrder>(
+        &self,
+        buf: &mut B,
+        ctx: (),
+    ) -> ::parsely_rs::ParselyResult<()> {
+        let __value_assertion_func = |v: &u8| *v % 2 == 0;
+        if !__value_assertion_func(&self.value) {
+            return ::anyhow::__private::Err(
+                ::anyhow::Error::msg(
+                    ::alloc::__export::must_use({
+                        let res = ::alloc::fmt::format(
+                            format_args!(
+                                "Assertion failed: value of field \'{0}\' (\'{1:?}\') didn\'t pass assertion: \'{2}\'",
+                                "value", self.value, | v : & u8 | * v % 2 == 0,
+                            ),
+                        );
+                        res
+                    }),
+                ),
+            );
+        }
+        u8::write::<T>(&self.value, buf, ())
+            .with_context(|| ::alloc::__export::must_use({
+                let res = ::alloc::fmt::format(
+                    format_args!("Writing field \'{0}\'", "value"),
+                );
+                res
+            }))?;
+        Ok(())
+    }
+}
+impl StateSync for Foo {
+    type SyncCtx = ();
+    fn sync(&mut self, (): ()) -> ParselyResult<()> {
+        self.value
+            .sync(())
+            .with_context(|| ::alloc::__export::must_use({
+                let res = ::alloc::fmt::format(
+                    format_args!("Syncing field \'{0}\'", "value"),
+                );
+                res
+            }))?;
+        Ok(())
+    }
+}

--- a/tests/expand/assertion.expanded.rs
+++ b/tests/expand/assertion.expanded.rs
@@ -18,7 +18,7 @@ impl<B: BitBuf> ::parsely_rs::ParselyRead<B, ()> for Foo {
                                 let res = ::alloc::fmt::format(
                                     format_args!(
                                         "Assertion failed: value of field \'{0}\' (\'{1:?}\') didn\'t pass assertion: \'{2}\'",
-                                        "value", read_value, | v : & u8 | * v % 2 == 0,
+                                        "value", read_value, "| v : & u8 | * v % 2 == 0",
                                     ),
                                 );
                                 res
@@ -32,12 +32,13 @@ impl<B: BitBuf> ::parsely_rs::ParselyRead<B, ()> for Foo {
         Ok(Self { value })
     }
 }
-impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
-    fn write<T: ::parsely_rs::ByteOrder>(
+impl ::parsely_rs::ParselyWrite for Foo {
+    type Ctx = ();
+    fn write<B: BitBufMut, T: ByteOrder>(
         &self,
         buf: &mut B,
-        ctx: (),
-    ) -> ::parsely_rs::ParselyResult<()> {
+        ctx: Self::Ctx,
+    ) -> ParselyResult<()> {
         let __value_assertion_func = |v: &u8| *v % 2 == 0;
         if !__value_assertion_func(&self.value) {
             return ::anyhow::__private::Err(
@@ -46,7 +47,7 @@ impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
                         let res = ::alloc::fmt::format(
                             format_args!(
                                 "Assertion failed: value of field \'{0}\' (\'{1:?}\') didn\'t pass assertion: \'{2}\'",
-                                "value", self.value, | v : & u8 | * v % 2 == 0,
+                                "value", self.value, "| v : & u8 | * v % 2 == 0",
                             ),
                         );
                         res
@@ -54,7 +55,7 @@ impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
                 ),
             );
         }
-        u8::write::<T>(&self.value, buf, ())
+        u8::write::<_, T>(&self.value, buf, ())
             .with_context(|| ::alloc::__export::must_use({
                 let res = ::alloc::fmt::format(
                     format_args!("Writing field \'{0}\'", "value"),

--- a/tests/expand/assertion.rs
+++ b/tests/expand/assertion.rs
@@ -1,0 +1,7 @@
+use parsely_rs::*;
+
+#[derive(ParselyRead, ParselyWrite)]
+struct Foo {
+    #[parsely(assertion = "|v: &u8| *v % 2 == 0")]
+    value: u8,
+}

--- a/tests/expand/map.expanded.rs
+++ b/tests/expand/map.expanded.rs
@@ -18,7 +18,7 @@ impl<B: BitBuf> ::parsely_rs::ParselyRead<B, ()> for Foo {
                     res
                 }))?;
             (|v: u8| { v.to_string() })(original_value)
-                .into_parsely_result()
+                .into_parsely_result_read()
                 .with_context(|| ::alloc::__export::must_use({
                     let res = ::alloc::fmt::format(
                         format_args!("Mapping raw value for field \'{0}\'", "value"),
@@ -30,12 +30,13 @@ impl<B: BitBuf> ::parsely_rs::ParselyRead<B, ()> for Foo {
         Ok(Self { value })
     }
 }
-impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
-    fn write<T: ::parsely_rs::ByteOrder>(
+impl ::parsely_rs::ParselyWrite for Foo {
+    type Ctx = ();
+    fn write<B: BitBufMut, T: ByteOrder>(
         &self,
         buf: &mut B,
-        ctx: (),
-    ) -> ::parsely_rs::ParselyResult<()> {
+        ctx: Self::Ctx,
+    ) -> ParselyResult<()> {
         {
             let mapped_value = (|v: &str| { v.parse::<u8>() })(&self.value)
                 .into_parsely_result()
@@ -45,7 +46,7 @@ impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
                     );
                     res
                 }))?;
-            ::parsely_rs::ParselyWrite::write::<T>(&mapped_value, buf, ())
+            ::parsely_rs::ParselyWrite::write::<B, T>(&mapped_value, buf, ())
                 .with_context(|| ::alloc::__export::must_use({
                     let res = ::alloc::fmt::format(
                         format_args!("Writing mapped value for field \'{0}\'", "value"),

--- a/tests/expand/map.expanded.rs
+++ b/tests/expand/map.expanded.rs
@@ -1,0 +1,72 @@
+use parsely_rs::*;
+struct Foo {
+    #[parsely_read(map = "|v: u8| { v.to_string() }")]
+    #[parsely_write(map = "|v: &str| { v.parse::<u8>() }")]
+    value: String,
+}
+impl<B: BitBuf> ::parsely_rs::ParselyRead<B, ()> for Foo {
+    fn read<T: ::parsely_rs::ByteOrder>(
+        buf: &mut B,
+        _ctx: (),
+    ) -> ::parsely_rs::ParselyResult<Self> {
+        let value = {
+            let original_value = ::parsely_rs::ParselyRead::read::<T>(buf, ())
+                .with_context(|| ::alloc::__export::must_use({
+                    let res = ::alloc::fmt::format(
+                        format_args!("Reading raw value for field \'{0}\'", "value"),
+                    );
+                    res
+                }))?;
+            (|v: u8| { v.to_string() })(original_value)
+                .into_parsely_result()
+                .with_context(|| ::alloc::__export::must_use({
+                    let res = ::alloc::fmt::format(
+                        format_args!("Mapping raw value for field \'{0}\'", "value"),
+                    );
+                    res
+                }))
+        }
+            .with_context(|| "Reading field 'value'")?;
+        Ok(Self { value })
+    }
+}
+impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B, ()> for Foo {
+    fn write<T: ::parsely_rs::ByteOrder>(
+        &self,
+        buf: &mut B,
+        ctx: (),
+    ) -> ::parsely_rs::ParselyResult<()> {
+        {
+            let mapped_value = (|v: &str| { v.parse::<u8>() })(&self.value)
+                .into_parsely_result()
+                .with_context(|| ::alloc::__export::must_use({
+                    let res = ::alloc::fmt::format(
+                        format_args!("Mapping raw value for field \'{0}\'", "value"),
+                    );
+                    res
+                }))?;
+            ::parsely_rs::ParselyWrite::write::<T>(&mapped_value, buf, ())
+                .with_context(|| ::alloc::__export::must_use({
+                    let res = ::alloc::fmt::format(
+                        format_args!("Writing mapped value for field \'{0}\'", "value"),
+                    );
+                    res
+                }))?;
+        }
+        Ok(())
+    }
+}
+impl StateSync for Foo {
+    type SyncCtx = ();
+    fn sync(&mut self, (): ()) -> ParselyResult<()> {
+        self.value
+            .sync(())
+            .with_context(|| ::alloc::__export::must_use({
+                let res = ::alloc::fmt::format(
+                    format_args!("Syncing field \'{0}\'", "value"),
+                );
+                res
+            }))?;
+        Ok(())
+    }
+}

--- a/tests/expand/map.rs
+++ b/tests/expand/map.rs
@@ -1,0 +1,8 @@
+use parsely_rs::*;
+
+#[derive(ParselyRead, ParselyWrite)]
+struct Foo {
+    #[parsely_read(map = "|v: u8| { v.to_string() }")]
+    #[parsely_write(map = "|v: &str| { v.parse::<u8>() }")]
+    value: String,
+}

--- a/tests/ui/pass/alignment.rs
+++ b/tests/ui/pass/alignment.rs
@@ -15,6 +15,6 @@ fn main() {
 
     let mut bits_mut = BitsMut::new();
 
-    Foo::write::<NetworkOrder>(&foo, &mut bits_mut, ()).unwrap();
+    Foo::write::<_, NetworkOrder>(&foo, &mut bits_mut, ()).unwrap();
     assert_eq!(bits_mut.len_bytes(), 4);
 }

--- a/tests/ui/pass/basic_write.rs
+++ b/tests/ui/pass/basic_write.rs
@@ -1,0 +1,17 @@
+use parsely_rs::*;
+
+#[derive(ParselyWrite)]
+struct Foo {
+    one: bool,
+    two: u3,
+}
+
+fn main() {
+    let mut bits_mut = BitsMut::new();
+    let foo = Foo {
+        one: true,
+        two: u3::new(4),
+    };
+
+    Foo::write::<NetworkOrder>(&mut bits_mut, ()).unwrap();
+}

--- a/tests/ui/pass/basic_write.rs
+++ b/tests/ui/pass/basic_write.rs
@@ -13,5 +13,5 @@ fn main() {
         two: u3::new(4),
     };
 
-    Foo::write::<NetworkOrder>(&mut bits_mut, ()).unwrap();
+    Foo::write::<_, NetworkOrder>(&foo, &mut bits_mut, ()).unwrap();
 }

--- a/tests/ui/pass/map.rs
+++ b/tests/ui/pass/map.rs
@@ -2,8 +2,6 @@ use parsely_rs::*;
 
 #[derive(ParselyRead, ParselyWrite)]
 struct Foo {
-    // #[parsely_read(map = "|v: u8| -> ParselyResult<String> { Ok(v.to_string()) }")]
-    // #[parsely_write(map = "|v: &str| -> ParselyResult<u8> { Ok(v.parse()?) }")]
     #[parsely_read(map = "|v: u8| { v.to_string() }")]
     #[parsely_write(map = "|v: &str| { v.parse::<u8>() }")]
     value: String,
@@ -21,7 +19,8 @@ fn main() {
         value: String::from("42"),
     };
 
-    foo.write::<NetworkOrder>(&mut bits_mut, ())
+    foo.write::<_, NetworkOrder>(&mut bits_mut, ())
         .expect("successful write");
+    let mut bits = bits_mut.freeze();
     assert_eq!(bits.get_u8().unwrap(), 42);
 }

--- a/tests/ui/pass/map.rs
+++ b/tests/ui/pass/map.rs
@@ -1,24 +1,25 @@
-use bitvec::prelude::*;
 use parsely_rs::*;
 
 #[derive(ParselyRead, ParselyWrite)]
 struct Foo {
-    #[parsely_read(map = "|v: u1| -> ParselyResult<bool> { Ok(v > 0) }")]
-    #[parsely_write(map = "|v: &bool| -> ParselyResult<u1> { Ok(u1::from(*v)) }")]
-    one: bool,
+    #[parsely_read(map = "|v: u8| { v.to_string() }")]
+    #[parsely_write(map = "|v: &str| { v.parse() }")]
+    value: String,
 }
 
 fn main() {
-    let mut bits = Bits::from_static_bytes(&[0b10101010]);
+    let mut bits = Bits::from_static_bytes(&[42]);
 
     let foo = Foo::read::<NetworkOrder>(&mut bits, ()).expect("successful parse");
-    assert!(foo.one);
+    assert_eq!(foo.value, "42");
 
     let mut bits_mut = BitsMut::new();
 
-    let foo = Foo { one: true };
+    let foo = Foo {
+        value: String::from("42"),
+    };
 
     foo.write::<NetworkOrder>(&mut bits_mut, ())
         .expect("successful write");
-    assert_eq!(&bits_mut[..], bits![u8, Msb0; 1]);
+    assert_eq!(bits.get_u8().unwrap(), 42);
 }

--- a/tests/ui/pass/map.rs
+++ b/tests/ui/pass/map.rs
@@ -2,8 +2,10 @@ use parsely_rs::*;
 
 #[derive(ParselyRead, ParselyWrite)]
 struct Foo {
+    // #[parsely_read(map = "|v: u8| -> ParselyResult<String> { Ok(v.to_string()) }")]
+    // #[parsely_write(map = "|v: &str| -> ParselyResult<u8> { Ok(v.parse()?) }")]
     #[parsely_read(map = "|v: u8| { v.to_string() }")]
-    #[parsely_write(map = "|v: &str| { v.parse() }")]
+    #[parsely_write(map = "|v: &str| { v.parse::<u8>() }")]
     value: String,
 }
 

--- a/tests/ui/pass/sync.rs
+++ b/tests/ui/pass/sync.rs
@@ -7,10 +7,10 @@ use parsely_rs::*;
 struct Header {
     version: u8,
     packet_type: u8,
-    // sync_func can refer to an expression or a function and will be used to update the annotated
+    // sync_expr can refer to an expression or a function and will be used to update the annotated
     // field, it should evaluate to ParselyResult<T> where T is the type of the field.  You can
     // refer to variables defined in sync_args
-    #[parsely_write(sync_func = "ParselyResult::Ok(payload_length_bytes + 4)")]
+    #[parsely_write(sync_expr = "payload_length_bytes + 4")]
     length_bytes: u16,
 }
 


### PR DESCRIPTION
This is a bunch of code that all sorta bled together.  Some of it could probably be split off but, here we are.

First changes were to change how `StateSync` is defined: the `Ctx` var was moved to an associated type and `StateSync` is now a required supertrait of `ParselyWrite`.  The idea here was to try and eliminate the possibility of a 'forgotten' sync call.

Then I got into the idea of making expressions that are passed in attributes more ergonomic.  Previously, when using something like a closer, the return type needed to be explicitly state and the result had to be a `ParselyResult`.  This makes the annotations feel a lot more verbose.  I want to be able to go from:

```rust
    #[parsely_read(map = "|v: u8| -> ParselyResult<String> { Ok(v.to_string()) }")]
```
to
```rust
    #[parsely_read(map = "|v: u8| { v.to_string() }")]
```
while also allowing
```
    #[parsely_write(map = "|v: &str| { v.parse::<u8>() }")]
```
(where v.parse::<u8>() returns a `Result` type) all while keeping things terse.  This sent me down a whole rabbit hole that resulted in refactoring the definition of the `ParselyWrite` trait to shift around some generics, but so far it does appear to be working as expected.

I also cleaned up some of the codegen code.  It's in better shape but lots of work still necessary there.