### PR TITLE
feat: trait rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "bits-io"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334d5023bf30d7edb7798b4dbbef2e2d3c121ecd885445cb1f6b0dbe879ab5e8"
+checksum = "db8ee456cc74052abbbfc9e94cff1484c5b23b200aec976a47854078bc16a272"
 dependencies = [
  "bitvec",
  "bytes",

--- a/Notes.md
+++ b/Notes.md
@@ -486,3 +486,23 @@ after doing the code I realized I had no good way to test it because the
 built-in buf doesn't provide anything that could be used with it, which makes
 me think putting it in parsely might not make sense.  This use case _could_
 have used the custom reader attribute, maybe?
+
+### Using ParselyRead/ParselyWrite with types other than BitBuf/BitBufMut
+
+For things like RTP parsing, we don't want to use the BitBuf/BitBufMut
+abstractions because they limit the efficiency we can get when we use
+Bits/BitsMut directly.  It would be nice to be able to leverage
+ParselyRead/ParselyWrite for other types as well: i.e. manually implementing it
+for the RTP packet types.  The problem is that the trait bound
+(BitBuf/BitBufMut) is built into the trait, so we can't really do that.  I
+looked at changing the "buffer" type to be an associated type, but that has a
+couple problems:
+
+* We can't do `type Buf = impl BitBuf` or `type Buf = dyn BitBUf` so we lose
+the ability to say "some BitBuf type".  We _could_ add another layer of
+indirection here, but that's a bit of a bummer.
+* Supporting multiple buffer types also makes me think that it'd be nice to be
+able to provide different/optimized read/write impls for different types (e.g.
+one for BitBuf and another when we know it's a Bits specifically or something)
+
+--> look into a refactoring of the read/write traits to accomplish this

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -7,7 +7,7 @@ description = "Macro-based struct serialization/deserialization"
 
 [dependencies]
 anyhow = "1"
-bits-io = { version = "0.5.4" }
+bits-io = { version = "0.5.5" }
 darling = "0.20.10"
 paste = "1"
 proc-macro2 = "1"

--- a/impl/src/code_gen/gen_read.rs
+++ b/impl/src/code_gen/gen_read.rs
@@ -24,7 +24,7 @@ pub fn generate_parsely_read_impl(data: ParselyReadData) -> TokenStream {
 
 fn generate_plain_read(ty: &syn::Type, context_values: &[syn::Expr]) -> TokenStream {
     quote! {
-        #ty::read::<_, T>(buf, (#(#context_values,)*))
+        #ty::read::<T>(buf, (#(#context_values,)*))
     }
 }
 
@@ -202,9 +202,9 @@ fn generate_parsely_read_impl_struct(
     };
 
     quote! {
-        impl ::#crate_name::ParselyRead for #struct_name {
+        impl<B: BitBuf> ::#crate_name::ParselyRead<B> for #struct_name {
             type Ctx = (#(#context_types,)*);
-            fn read<B: BitBuf, T: ::#crate_name::ByteOrder>(buf: &mut B, #ctx_var: (#(#context_types,)*)) -> ::#crate_name::ParselyResult<Self> {
+            fn read<T: ::#crate_name::ByteOrder>(buf: &mut B, #ctx_var: (#(#context_types,)*)) -> ::#crate_name::ParselyResult<Self> {
                 #(#context_assignments)*
 
                 #body

--- a/impl/src/code_gen/gen_read.rs
+++ b/impl/src/code_gen/gen_read.rs
@@ -182,11 +182,8 @@ fn generate_parsely_read_impl_struct(
 
             #(#field_reads)*
 
-            let __bytes_remaining_end = buf.remaining_bytes();
-            let mut __amount_read = __bytes_remaining_start - __bytes_remaining_end;
-            while __amount_read % #alignment != 0 {
+            while (__bytes_remaining_start - buf.remaining_bytes()) % #alignment != 0 {
                 buf.get_u8().context("padding")?;
-                __amount_read += 1;
             }
         }
     } else {

--- a/impl/src/code_gen/gen_write.rs
+++ b/impl/src/code_gen/gen_write.rs
@@ -127,11 +127,8 @@ fn generate_parsely_write_impl_struct(
 
             #(#field_writes)*
 
-            let __bytes_remaining_end = buf.remaining_mut_bytes();
-            let mut __amount_written = __bytes_remaining_start - __bytes_remaining_end;
-            while __amount_written % #alignment != 0 {
+            while (__bytes_remaining_start - buf.remaining_mut_bytes()) % #alignment != 0 {
                 let _ = buf.put_u8(0).context("padding")?;
-                __amount_written += 1;
             }
 
         }

--- a/impl/src/code_gen/gen_write.rs
+++ b/impl/src/code_gen/gen_write.rs
@@ -104,7 +104,7 @@ fn generate_parsely_write_impl_struct(
             let field_name_string = field_name.to_string();
             if let Some(ref sync_expr) = f.sync_expr {
                 quote! {
-                    self.#field_name = (#sync_expr).into_parsely_result_read().with_context(|| format!("Syncing field '{}'", #field_name_string))?;
+                    self.#field_name = (#sync_expr).into_parsely_result().with_context(|| format!("Syncing field '{}'", #field_name_string))?;
                 }
             } else if f.sync_with.is_empty() && f.ty.is_wrapped() {
                 // We'll allow this combination to skip a call to sync: for types like Option<T> or

--- a/impl/src/error.rs
+++ b/impl/src/error.rs
@@ -36,11 +36,11 @@ where
 // expression evaluation where the writable limitations also don't exist, but aren't exactly on the
 // 'read path' (for example when syncing state)
 pub trait IntoParselyResult<T> {
-    fn into_parsely_result_read(self) -> ParselyResult<T>;
+    fn into_parsely_result(self) -> ParselyResult<T>;
 }
 
 impl<T> IntoParselyResult<T> for T {
-    fn into_parsely_result_read(self) -> ParselyResult<T> {
+    fn into_parsely_result(self) -> ParselyResult<T> {
         Ok(self)
     }
 }
@@ -49,7 +49,7 @@ impl<T, E> IntoParselyResult<T> for Result<T, E>
 where
     E: Into<anyhow::Error>,
 {
-    fn into_parsely_result_read(self) -> ParselyResult<T> {
+    fn into_parsely_result(self) -> ParselyResult<T> {
         self.map_err(Into::into)
     }
 }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -17,6 +17,7 @@ pub use bits_io::{
 };
 
 pub mod nsw_types {
+    pub use bits_io::nsw_types::from_bitslice::BitSliceUxExts;
     pub use bits_io::nsw_types::*;
 }
 

--- a/impl/src/model_types.rs
+++ b/impl/src/model_types.rs
@@ -261,7 +261,7 @@ impl MapExpr {
         // value?
         tokens.extend(quote! {
             {
-                let original_value = ::#crate_name::ParselyRead::read::<_, T>(buf, ())
+                let original_value = ::#crate_name::ParselyRead::read::<T>(buf, ())
                     .with_context(|| format!("Reading raw value for field '{}'", #field_name_string))?;
                 (#map_expr)(original_value).into_parsely_result()
                     .with_context(|| format!("Mapping raw value for field '{}'", #field_name_string))

--- a/impl/src/model_types.rs
+++ b/impl/src/model_types.rs
@@ -81,7 +81,7 @@ impl Context {
             .enumerate()
             .map(|(idx, e)| {
                 syn::parse2(quote! {
-                    (#e).into_parsely_result_read().with_context(|| format!("{}: expression {}", #context, #idx))?
+                    (#e).into_parsely_result().with_context(|| format!("{}: expression {}", #context, #idx))?
                 })
                 .unwrap()
             })
@@ -263,7 +263,7 @@ impl MapExpr {
             {
                 let original_value = ::#crate_name::ParselyRead::read::<_, T>(buf, ())
                     .with_context(|| format!("Reading raw value for field '{}'", #field_name_string))?;
-                (#map_expr)(original_value).into_parsely_result_read()
+                (#map_expr)(original_value).into_parsely_result()
                     .with_context(|| format!("Mapping raw value for field '{}'", #field_name_string))
             }
         })

--- a/impl/src/parsely_read.rs
+++ b/impl/src/parsely_read.rs
@@ -2,16 +2,16 @@ use bits_io::prelude::*;
 
 use crate::error::ParselyResult;
 
-pub trait ParselyRead: Sized {
+pub trait ParselyRead<B>: Sized {
     type Ctx;
-    fn read<B: BitBuf, T: ByteOrder>(buf: &mut B, ctx: Self::Ctx) -> ParselyResult<Self>;
+    fn read<T: ByteOrder>(buf: &mut B, ctx: Self::Ctx) -> ParselyResult<Self>;
 }
 
 macro_rules! impl_parsely_read_builtin {
     ($type:ty) => {
-        impl ParselyRead for $type {
+        impl<B: BitBuf> ParselyRead<B> for $type {
             type Ctx = ();
-            fn read<B: BitBuf, T: ByteOrder>(buf: &mut B, _: Self::Ctx) -> ParselyResult<Self> {
+            fn read<T: ByteOrder>(buf: &mut B, _: Self::Ctx) -> ParselyResult<Self> {
                 ::paste::paste! {
                     Ok(buf.[<get_ $type>]()?)
                 }
@@ -22,9 +22,9 @@ macro_rules! impl_parsely_read_builtin {
 
 macro_rules! impl_parsely_read_builtin_bo {
     ($type:ty) => {
-        impl ParselyRead for $type {
+        impl<B: BitBuf> ParselyRead<B> for $type {
             type Ctx = ();
-            fn read<B: BitBuf, T: ByteOrder>(buf: &mut B, _: Self::Ctx) -> ParselyResult<Self> {
+            fn read<T: ByteOrder>(buf: &mut B, _: Self::Ctx) -> ParselyResult<Self> {
                 ::paste::paste! {
                     Ok(buf.[<get_ $type>]::<T>()?)
                 }
@@ -33,9 +33,9 @@ macro_rules! impl_parsely_read_builtin_bo {
     };
 }
 
-impl ParselyRead for bool {
+impl<B: BitBuf> ParselyRead<B> for bool {
     type Ctx = ();
-    fn read<B: BitBuf, T: ByteOrder>(buf: &mut B, _ctx: Self::Ctx) -> ParselyResult<Self> {
+    fn read<T: ByteOrder>(buf: &mut B, _ctx: Self::Ctx) -> ParselyResult<Self> {
         Ok(buf.get_bool()?)
     }
 }

--- a/impl/src/parsely_write.rs
+++ b/impl/src/parsely_write.rs
@@ -22,22 +22,6 @@ macro_rules! impl_stateless_sync {
     };
 }
 
-/// A marker trait so it can be used as a trait bound
-pub trait ParselyWritable {
-    #[doc(hidden)]
-    fn _dummy_write<B, O, C>(buf: &mut B, order: O, ctx: C)
-    where
-        Self: ParselyWrite<B>;
-}
-
-impl<T> ParselyWritable for T {
-    fn _dummy_write<B, O, C>(_buf: &mut B, _order: O, _ctx: C)
-    where
-        T: ParselyWrite<B>,
-    {
-    }
-}
-
 pub trait ParselyWrite<B>: StateSync + Sized {
     type Ctx;
     fn write<T: ByteOrder>(&self, buf: &mut B, ctx: Self::Ctx) -> ParselyResult<()>;

--- a/tests/expand/alignment.expanded.rs
+++ b/tests/expand/alignment.expanded.rs
@@ -20,15 +20,11 @@ impl ::parsely_rs::ParselyRead for Foo {
         Ok(Self { one })
     }
 }
-impl ::parsely_rs::ParselyWrite for Foo {
+impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B> for Foo {
     type Ctx = ();
-    fn write<B: BitBufMut, T: ByteOrder>(
-        &self,
-        buf: &mut B,
-        ctx: Self::Ctx,
-    ) -> ParselyResult<()> {
+    fn write<T: ByteOrder>(&self, buf: &mut B, ctx: Self::Ctx) -> ParselyResult<()> {
         let __bytes_remaining_start = buf.remaining_mut_bytes();
-        u8::write::<_, T>(&self.one, buf, ())
+        u8::write::<T>(&self.one, buf, ())
             .with_context(|| ::alloc::__export::must_use({
                 let res = ::alloc::fmt::format(
                     format_args!("Writing field \'{0}\'", "one"),

--- a/tests/expand/alignment.expanded.rs
+++ b/tests/expand/alignment.expanded.rs
@@ -11,11 +11,8 @@ impl<B: BitBuf> ::parsely_rs::ParselyRead<B> for Foo {
     ) -> ::parsely_rs::ParselyResult<Self> {
         let __bytes_remaining_start = buf.remaining_bytes();
         let one = u8::read::<T>(buf, ()).with_context(|| "Reading field 'one'")?;
-        let __bytes_remaining_end = buf.remaining_bytes();
-        let mut __amount_read = __bytes_remaining_start - __bytes_remaining_end;
-        while __amount_read % 4usize != 0 {
+        while (__bytes_remaining_start - buf.remaining_bytes()) % 4usize != 0 {
             buf.get_u8().context("padding")?;
-            __amount_read += 1;
         }
         Ok(Self { one })
     }
@@ -31,11 +28,8 @@ impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B> for Foo {
                 );
                 res
             }))?;
-        let __bytes_remaining_end = buf.remaining_mut_bytes();
-        let mut __amount_written = __bytes_remaining_start - __bytes_remaining_end;
-        while __amount_written % 4usize != 0 {
+        while (__bytes_remaining_start - buf.remaining_mut_bytes()) % 4usize != 0 {
             let _ = buf.put_u8(0).context("padding")?;
-            __amount_written += 1;
         }
         Ok(())
     }

--- a/tests/expand/alignment.expanded.rs
+++ b/tests/expand/alignment.expanded.rs
@@ -3,14 +3,14 @@ use parsely_rs::*;
 struct Foo {
     one: u8,
 }
-impl ::parsely_rs::ParselyRead for Foo {
+impl<B: BitBuf> ::parsely_rs::ParselyRead<B> for Foo {
     type Ctx = ();
-    fn read<B: BitBuf, T: ::parsely_rs::ByteOrder>(
+    fn read<T: ::parsely_rs::ByteOrder>(
         buf: &mut B,
         _ctx: (),
     ) -> ::parsely_rs::ParselyResult<Self> {
         let __bytes_remaining_start = buf.remaining_bytes();
-        let one = u8::read::<_, T>(buf, ()).with_context(|| "Reading field 'one'")?;
+        let one = u8::read::<T>(buf, ()).with_context(|| "Reading field 'one'")?;
         let __bytes_remaining_end = buf.remaining_bytes();
         let mut __amount_read = __bytes_remaining_start - __bytes_remaining_end;
         while __amount_read % 4usize != 0 {

--- a/tests/expand/assertion.expanded.rs
+++ b/tests/expand/assertion.expanded.rs
@@ -3,13 +3,13 @@ struct Foo {
     #[parsely(assertion = "|v: &u8| *v % 2 == 0")]
     value: u8,
 }
-impl ::parsely_rs::ParselyRead for Foo {
+impl<B: BitBuf> ::parsely_rs::ParselyRead<B> for Foo {
     type Ctx = ();
-    fn read<B: BitBuf, T: ::parsely_rs::ByteOrder>(
+    fn read<T: ::parsely_rs::ByteOrder>(
         buf: &mut B,
         _ctx: (),
     ) -> ::parsely_rs::ParselyResult<Self> {
-        let value = u8::read::<_, T>(buf, ())
+        let value = u8::read::<T>(buf, ())
             .and_then(|read_value| {
                 let assertion_func = |v: &u8| *v % 2 == 0;
                 if !assertion_func(&read_value) {

--- a/tests/expand/assertion.expanded.rs
+++ b/tests/expand/assertion.expanded.rs
@@ -33,13 +33,9 @@ impl ::parsely_rs::ParselyRead for Foo {
         Ok(Self { value })
     }
 }
-impl ::parsely_rs::ParselyWrite for Foo {
+impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B> for Foo {
     type Ctx = ();
-    fn write<B: BitBufMut, T: ByteOrder>(
-        &self,
-        buf: &mut B,
-        ctx: Self::Ctx,
-    ) -> ParselyResult<()> {
+    fn write<T: ByteOrder>(&self, buf: &mut B, ctx: Self::Ctx) -> ParselyResult<()> {
         let __value_assertion_func = |v: &u8| *v % 2 == 0;
         if !__value_assertion_func(&self.value) {
             return ::anyhow::__private::Err(
@@ -56,7 +52,7 @@ impl ::parsely_rs::ParselyWrite for Foo {
                 ),
             );
         }
-        u8::write::<_, T>(&self.value, buf, ())
+        u8::write::<T>(&self.value, buf, ())
             .with_context(|| ::alloc::__export::must_use({
                 let res = ::alloc::fmt::format(
                     format_args!("Writing field \'{0}\'", "value"),

--- a/tests/expand/map.expanded.rs
+++ b/tests/expand/map.expanded.rs
@@ -31,23 +31,22 @@ impl ::parsely_rs::ParselyRead for Foo {
         Ok(Self { value })
     }
 }
-impl ::parsely_rs::ParselyWrite for Foo {
+impl<B: BitBufMut> ::parsely_rs::ParselyWrite<B> for Foo {
     type Ctx = ();
-    fn write<B: BitBufMut, T: ByteOrder>(
-        &self,
-        buf: &mut B,
-        ctx: Self::Ctx,
-    ) -> ParselyResult<()> {
+    fn write<T: ByteOrder>(&self, buf: &mut B, ctx: Self::Ctx) -> ParselyResult<()> {
         {
-            let mapped_value = (|v: &str| { v.parse::<u8>() })(&self.value)
-                .into_parsely_result()
+            let mapped_value = (|v: &str| { v.parse::<u8>() })(&self.value);
+            let result = <_ as IntoWritableParselyResult<
+                _,
+                B,
+            >>::into_writable_parsely_result(mapped_value)
                 .with_context(|| ::alloc::__export::must_use({
                     let res = ::alloc::fmt::format(
                         format_args!("Mapping raw value for field \'{0}\'", "value"),
                     );
                     res
                 }))?;
-            ::parsely_rs::ParselyWrite::write::<B, T>(&mapped_value, buf, ())
+            ::parsely_rs::ParselyWrite::write::<T>(&result, buf, ())
                 .with_context(|| ::alloc::__export::must_use({
                     let res = ::alloc::fmt::format(
                         format_args!("Writing mapped value for field \'{0}\'", "value"),

--- a/tests/expand/map.expanded.rs
+++ b/tests/expand/map.expanded.rs
@@ -19,7 +19,7 @@ impl ::parsely_rs::ParselyRead for Foo {
                     res
                 }))?;
             (|v: u8| { v.to_string() })(original_value)
-                .into_parsely_result_read()
+                .into_parsely_result()
                 .with_context(|| ::alloc::__export::must_use({
                     let res = ::alloc::fmt::format(
                         format_args!("Mapping raw value for field \'{0}\'", "value"),

--- a/tests/expand/map.expanded.rs
+++ b/tests/expand/map.expanded.rs
@@ -4,14 +4,14 @@ struct Foo {
     #[parsely_write(map = "|v: &str| { v.parse::<u8>() }")]
     value: String,
 }
-impl ::parsely_rs::ParselyRead for Foo {
+impl<B: BitBuf> ::parsely_rs::ParselyRead<B> for Foo {
     type Ctx = ();
-    fn read<B: BitBuf, T: ::parsely_rs::ByteOrder>(
+    fn read<T: ::parsely_rs::ByteOrder>(
         buf: &mut B,
         _ctx: (),
     ) -> ::parsely_rs::ParselyResult<Self> {
         let value = {
-            let original_value = ::parsely_rs::ParselyRead::read::<_, T>(buf, ())
+            let original_value = ::parsely_rs::ParselyRead::read::<T>(buf, ())
                 .with_context(|| ::alloc::__export::must_use({
                     let res = ::alloc::fmt::format(
                         format_args!("Reading raw value for field \'{0}\'", "value"),

--- a/tests/ui/pass/alignment.rs
+++ b/tests/ui/pass/alignment.rs
@@ -9,7 +9,7 @@ struct Foo {
 fn main() {
     let mut bits = Bits::from_static_bytes(&[42, 0, 0, 0]);
 
-    let foo = Foo::read::<_, NetworkOrder>(&mut bits, ()).unwrap();
+    let foo = Foo::read::<NetworkOrder>(&mut bits, ()).unwrap();
     assert_eq!(foo.one, 42);
     assert_eq!(bits.remaining_bytes(), 0);
 

--- a/tests/ui/pass/alignment.rs
+++ b/tests/ui/pass/alignment.rs
@@ -15,6 +15,6 @@ fn main() {
 
     let mut bits_mut = BitsMut::new();
 
-    Foo::write::<_, NetworkOrder>(&foo, &mut bits_mut, ()).unwrap();
+    Foo::write::<NetworkOrder>(&foo, &mut bits_mut, ()).unwrap();
     assert_eq!(bits_mut.len_bytes(), 4);
 }

--- a/tests/ui/pass/basic_read.rs
+++ b/tests/ui/pass/basic_read.rs
@@ -8,6 +8,6 @@ struct Foo {
 fn main() {
     let mut cursor = Bits::from_static_bytes(&[0b10101010]);
 
-    let foo = Foo::read::<_, NetworkOrder>(&mut cursor, ()).expect("successful parse");
+    let foo = Foo::read::<NetworkOrder>(&mut cursor, ()).expect("successful parse");
     assert!(foo.one);
 }

--- a/tests/ui/pass/basic_write.rs
+++ b/tests/ui/pass/basic_write.rs
@@ -13,5 +13,5 @@ fn main() {
         two: u3::new(4),
     };
 
-    Foo::write::<_, NetworkOrder>(&foo, &mut bits_mut, ()).unwrap();
+    Foo::write::<NetworkOrder>(&foo, &mut bits_mut, ()).unwrap();
 }

--- a/tests/ui/pass/context.rs
+++ b/tests/ui/pass/context.rs
@@ -20,7 +20,7 @@ struct Foo {
 
 fn main() {
     let mut bits = Bits::from_static_bytes(&[1, 2, 3, 4]);
-    let foo = Foo::read::<_, NetworkOrder>(&mut bits, (2,)).expect("successful parse");
+    let foo = Foo::read::<NetworkOrder>(&mut bits, (2,)).expect("successful parse");
 
     // Should have only read 2 values
     assert_eq!(foo.data.len(), 2);

--- a/tests/ui/pass/count.rs
+++ b/tests/ui/pass/count.rs
@@ -10,6 +10,6 @@ struct Foo {
 fn main() {
     let mut bits = Bits::from_static_bytes(&[2, 1, 2, 3]);
 
-    let foo = Foo::read::<_, NetworkOrder>(&mut bits, ()).expect("successful parse");
+    let foo = Foo::read::<NetworkOrder>(&mut bits, ()).expect("successful parse");
     assert_eq!(foo.data.len(), 2);
 }

--- a/tests/ui/pass/map.rs
+++ b/tests/ui/pass/map.rs
@@ -12,7 +12,7 @@ struct Foo {
 fn main() {
     let mut bits = Bits::from_static_bytes(&[42]);
 
-    let foo = Foo::read::<_, NetworkOrder>(&mut bits, ()).expect("successful parse");
+    let foo = Foo::read::<NetworkOrder>(&mut bits, ()).expect("successful parse");
     assert_eq!(foo.value, "42");
 
     let mut bits_mut = BitsMut::new();

--- a/tests/ui/pass/map.rs
+++ b/tests/ui/pass/map.rs
@@ -21,7 +21,7 @@ fn main() {
         value: String::from("42"),
     };
 
-    foo.write::<_, NetworkOrder>(&mut bits_mut, ())
+    foo.write::<NetworkOrder>(&mut bits_mut, ())
         .expect("successful write");
     let mut bits = bits_mut.freeze();
     assert_eq!(bits.get_u8().unwrap(), 42);

--- a/tests/ui/pass/when.rs
+++ b/tests/ui/pass/when.rs
@@ -9,7 +9,7 @@ struct Foo {
 
 fn main() {
     let mut bits = Bits::from_static_bytes(&[0b1_0000001, 2]);
-    let foo = Foo::read::<_, NetworkOrder>(&mut bits, ()).expect("successful parse");
+    let foo = Foo::read::<NetworkOrder>(&mut bits, ()).expect("successful parse");
 
     assert_eq!(foo.value, Some(u7::new(1)));
 }

--- a/tests/ui/pass/while.rs
+++ b/tests/ui/pass/while.rs
@@ -9,6 +9,6 @@ struct Foo {
 fn main() {
     let mut bits = Bits::from_static_bytes(&[2, 1, 2, 3]);
 
-    let foo = Foo::read::<_, NetworkOrder>(&mut bits, ()).expect("successful parse");
+    let foo = Foo::read::<NetworkOrder>(&mut bits, ()).expect("successful parse");
     assert_eq!(foo.data.len(), 4);
 }


### PR DESCRIPTION
This tweaks the `ParselyRead` and `ParselyWrite` traits yet again in order to allow manual implementations of them using a custom type.  This is useful for some types which want to be able to operate on `Bits` directly instead of some generic `BitBuf` or if some other buffer type in general wants to be used.